### PR TITLE
Create an initial career page route with new shadcn and inspira components

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -18,5 +18,14 @@ export default defineConfigWithVueTs(
 
   pluginVue.configs['flat/essential'],
   vueTsConfigs.recommended,
+
+  // Disable the vue/multi-word-component-names rule for shadcn-vue components under src/components/ui
+  {
+    files: ['src/components/ui/**/*.vue'],
+    rules: {
+      'vue/multi-word-component-names': 'off',
+    },
+  },
+
   skipFormatting,
 )

--- a/index.html
+++ b/index.html
@@ -7,6 +7,50 @@
     <title>Vite App</title>
   </head>
   <body>
+    <!-- Apply persisted/system theme synchronously to avoid flash -->
+    <script>
+      (function () {
+        try {
+          // Check common storage keys used by color mode libraries (vueuse etc.)
+          const keys = ['vueuse-color-scheme', 'color-mode', 'theme']
+          let stored = null
+          for (const k of keys) {
+            const v = localStorage.getItem(k)
+            if (v) {
+              stored = v
+              break
+            }
+          }
+
+          if (stored === 'dark') {
+            document.documentElement.classList.add('dark')
+          } else if (stored === 'light') {
+            document.documentElement.classList.remove('dark')
+          } else {
+            // No stored preference — follow system preference
+            if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+              document.documentElement.classList.add('dark')
+            } else {
+              document.documentElement.classList.remove('dark')
+            }
+          }
+        } catch (e) {
+          // fail silently
+        }
+      })();
+    </script>
+
+    <!-- Minimal background colors to prevent white flash before full CSS loads -->
+    <style>
+      /* Light default */
+      :root { background-color: #ffffff; }
+      /* Dark default — tweak to match your theme's background */
+      .dark { background-color: #000000; }
+      /* Ensure body inherits document background immediately */
+      html, body { height: 100%; }
+      body { margin: 0; background: transparent; }
+    </style>
+
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@vueuse/core": "^14.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "embla-carousel-vue": "^8.6.0",
         "lucide-vue-next": "^0.552.0",
         "reka-ui": "^2.6.0",
         "tailwind-merge": "^3.3.1",
@@ -3148,6 +3149,35 @@
       "integrity": "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-vue": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-vue/-/embla-carousel-vue-8.6.0.tgz",
+      "integrity": "sha512-v8UO5UsyLocZnu/LbfQA7Dn2QHuZKurJY93VUmZYP//QRWoCWOsionmvLLAlibkET3pGPs7++03VhJKbWD7vhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.37"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "embla-carousel-vue": "^8.6.0",
         "lucide-vue-next": "^0.552.0",
         "reka-ui": "^2.6.0",
-        "tailwind-merge": "^3.3.1",
+        "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.16",
         "tw-animate-css": "^1.4.0",
         "vue": "^3.5.22",
@@ -5247,9 +5247,9 @@
       }
     },
     "node_modules/tailwind-merge": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
-      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@vueuse/core": "^14.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "embla-carousel-vue": "^8.6.0",
     "lucide-vue-next": "^0.552.0",
     "reka-ui": "^2.6.0",
     "tailwind-merge": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "embla-carousel-vue": "^8.6.0",
     "lucide-vue-next": "^0.552.0",
     "reka-ui": "^2.6.0",
-    "tailwind-merge": "^3.3.1",
+    "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.16",
     "tw-animate-css": "^1.4.0",
     "vue": "^3.5.22",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import AppSidebar from '@/components/AppSidebar.vue'
-import { SidebarProvider } from '@/components/ui/sidebar'
 import FlickeringGridBackground from '@/components/FlickeringGridBackground.vue'
+import { SidebarProvider } from '@/components/ui/sidebar'
 </script>
 
 <template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,13 +6,15 @@ import { SidebarProvider } from '@/components/ui/sidebar'
 
 <template>
   <SidebarProvider>
-    <!-- Make the whole viewport a flex container -->
-    <div class="flex min-h-screen w-screen overflow-hidden">
-      <!-- Sidebar takes its natural width -->
-      <AppSidebar />
+    <!-- Make the whole viewport a positioned container so sidebar can overlay -->
+    <div class="relative min-h-screen w-screen overflow-hidden">
+      <!-- Sidebar is positioned absolutely so it overlays (does NOT push content) -->
+      <div class="absolute top-0 left-0 z-50 h-full">
+        <AppSidebar />
+      </div>
 
-      <!-- Main content flexes to fill remaining space -->
-      <main class="flex-1 overflow-y-auto">
+      <!-- Main content stays full width and is drawn beneath the overlaying sidebar -->
+      <main class="relative z-0 flex-1 overflow-y-auto">
         <FlickeringGridBackground>
           <RouterView />
         </FlickeringGridBackground>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import AppSidebar from '@/components/AppSidebar.vue'
 import { SidebarProvider } from '@/components/ui/sidebar'
+import FlickeringGridBackground from '@/components/FlickeringGridBackground.vue'
 </script>
 
 <template>
@@ -12,7 +13,9 @@ import { SidebarProvider } from '@/components/ui/sidebar'
 
       <!-- Main content flexes to fill remaining space -->
       <main class="flex-1 overflow-y-auto">
-        <RouterView />
+        <FlickeringGridBackground>
+          <RouterView />
+        </FlickeringGridBackground>
       </main>
     </div>
   </SidebarProvider>

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -19,12 +19,12 @@ import {
 const items = [
   {
     title: 'Home',
-    url: '#',
+    url: '/',
     icon: Home
   },
   {
-    title: 'Experience',
-    url: '#',
+    title: 'Career',
+    url: '/career',
     icon: Briefcase
   },
   {

--- a/src/components/FlickeringGridBackground.vue
+++ b/src/components/FlickeringGridBackground.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import FlickeringGrid from '@/components/ui/flickering-grid/FlickeringGrid.vue'
+</script>
+
+<template>
+  <!-- 1. The main parent container (relative positioning, defined size) -->
+  <div class="relative w-full h-full overflow-hidden">
+
+    <!-- 2. The FlickeringGrid component (absolute positioned background) -->
+    <FlickeringGrid
+      class="absolute inset-0 z-0 pointer-events-none"
+      :square-size="8"
+      :grid-gap="8"
+      color="#50C878"
+      :max-opacity="0.125"
+      :flicker-chance=".1"
+    />
+
+    <!-- 3. Your foreground content wrapper (relative positioning, appears above the grid) -->
+    <div class="relative z-10 flex h-full items-center justify-center p-8">
+      <slot />
+    </div>
+
+  </div>
+</template>

--- a/src/components/FlickeringGridBackground.vue
+++ b/src/components/FlickeringGridBackground.vue
@@ -14,8 +14,8 @@ const gridColor = computed(() => {
 </script>
 
 <template>
-  <!-- 1. The main parent container (relative positioning, defined size) -->
-  <div class="relative h-full w-full overflow-hidden">
+  <!-- 1. The main parent container (relative positioning, ensures at least viewport height) -->
+  <div class="relative min-h-screen w-full overflow-hidden">
     <!-- 2. The FlickeringGrid component (absolute positioned background) -->
     <FlickeringGrid
       class="pointer-events-none absolute inset-0 z-0"
@@ -27,7 +27,7 @@ const gridColor = computed(() => {
     />
 
     <!-- 3. Your foreground content wrapper (relative positioning, appears above the grid) -->
-    <div class="relative z-10 flex h-full items-center justify-center p-8">
+    <div class="relative z-10 flex min-h-screen w-full items-center justify-center p-8">
       <slot />
     </div>
   </div>

--- a/src/components/FlickeringGridBackground.vue
+++ b/src/components/FlickeringGridBackground.vue
@@ -1,25 +1,34 @@
 <script setup lang="ts">
+import { useColorMode } from '@vueuse/core'
+
+import { computed } from 'vue'
+
 import FlickeringGrid from '@/components/ui/flickering-grid/FlickeringGrid.vue'
+
+const colorMode = useColorMode()
+
+const gridColor = computed(() => {
+  // emerald green for dark mode, forest green for light mode
+  return colorMode.value === 'light' ? '#0B6623' : '#50C878'
+})
 </script>
 
 <template>
   <!-- 1. The main parent container (relative positioning, defined size) -->
-  <div class="relative w-full h-full overflow-hidden">
-
+  <div class="relative h-full w-full overflow-hidden">
     <!-- 2. The FlickeringGrid component (absolute positioned background) -->
     <FlickeringGrid
-      class="absolute inset-0 z-0 pointer-events-none"
+      class="pointer-events-none absolute inset-0 z-0"
       :square-size="8"
       :grid-gap="8"
-      color="#50C878"
+      :color="gridColor"
       :max-opacity="0.125"
-      :flicker-chance=".1"
+      :flicker-chance="0.1"
     />
 
     <!-- 3. Your foreground content wrapper (relative positioning, appears above the grid) -->
     <div class="relative z-10 flex h-full items-center justify-center p-8">
       <slot />
     </div>
-
   </div>
 </template>

--- a/src/components/ui/card/Card.vue
+++ b/src/components/ui/card/Card.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card"
+    :class="
+      cn(
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/card/Card.vue
+++ b/src/components/ui/card/Card.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
     data-slot="card"
     :class="
       cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border-4 py-6 shadow-sm',
         props.class
       )
     "

--- a/src/components/ui/card/CardAction.vue
+++ b/src/components/ui/card/CardAction.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card-action"
+    :class="cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/card/CardContent.vue
+++ b/src/components/ui/card/CardContent.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div data-slot="card-content" :class="cn('px-6', props.class)">
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/card/CardDescription.vue
+++ b/src/components/ui/card/CardDescription.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <p data-slot="card-description" :class="cn('text-muted-foreground text-sm', props.class)">
+    <slot />
+  </p>
+</template>

--- a/src/components/ui/card/CardFooter.vue
+++ b/src/components/ui/card/CardFooter.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div data-slot="card-footer" :class="cn('flex items-center px-6 [.border-t]:pt-6', props.class)">
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/card/CardHeader.vue
+++ b/src/components/ui/card/CardHeader.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card-header"
+    :class="
+      cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/card/CardTitle.vue
+++ b/src/components/ui/card/CardTitle.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <h3 data-slot="card-title" :class="cn('leading-none font-semibold', props.class)">
+    <slot />
+  </h3>
+</template>

--- a/src/components/ui/card/index.ts
+++ b/src/components/ui/card/index.ts
@@ -1,0 +1,7 @@
+export { default as Card } from './Card.vue'
+export { default as CardAction } from './CardAction.vue'
+export { default as CardContent } from './CardContent.vue'
+export { default as CardDescription } from './CardDescription.vue'
+export { default as CardFooter } from './CardFooter.vue'
+export { default as CardHeader } from './CardHeader.vue'
+export { default as CardTitle } from './CardTitle.vue'

--- a/src/components/ui/carousel/Carousel.vue
+++ b/src/components/ui/carousel/Carousel.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+import type { CarouselEmits, CarouselProps, WithClassAsProps } from './interface'
+import { useProvideCarousel } from './useCarousel'
+
+const props = withDefaults(defineProps<CarouselProps & WithClassAsProps>(), {
+  orientation: 'horizontal'
+})
+
+const emits = defineEmits<CarouselEmits>()
+
+const {
+  canScrollNext,
+  canScrollPrev,
+  carouselApi,
+  carouselRef,
+  orientation,
+  scrollNext,
+  scrollPrev
+} = useProvideCarousel(props, emits)
+
+defineExpose({
+  canScrollNext,
+  canScrollPrev,
+  carouselApi,
+  carouselRef,
+  orientation,
+  scrollNext,
+  scrollPrev
+})
+
+function onKeyDown(event: KeyboardEvent) {
+  const prevKey = props.orientation === 'vertical' ? 'ArrowUp' : 'ArrowLeft'
+  const nextKey = props.orientation === 'vertical' ? 'ArrowDown' : 'ArrowRight'
+
+  if (event.key === prevKey) {
+    event.preventDefault()
+    scrollPrev()
+
+    return
+  }
+
+  if (event.key === nextKey) {
+    event.preventDefault()
+    scrollNext()
+  }
+}
+</script>
+
+<template>
+  <div
+    data-slot="carousel"
+    :class="cn('relative', props.class)"
+    role="region"
+    aria-roledescription="carousel"
+    tabindex="0"
+    @keydown="onKeyDown"
+  >
+    <slot
+      :can-scroll-next
+      :can-scroll-prev
+      :carousel-api
+      :carousel-ref
+      :orientation
+      :scroll-next
+      :scroll-prev
+    />
+  </div>
+</template>

--- a/src/components/ui/carousel/CarouselContent.vue
+++ b/src/components/ui/carousel/CarouselContent.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+import type { WithClassAsProps } from './interface'
+import { useCarousel } from './useCarousel'
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const props = defineProps<WithClassAsProps>()
+
+const { carouselRef, orientation } = useCarousel()
+</script>
+
+<template>
+  <div ref="carouselRef" data-slot="carousel-content" class="overflow-hidden">
+    <div
+      :class="cn('flex', orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col', props.class)"
+      v-bind="$attrs"
+    >
+      <slot />
+    </div>
+  </div>
+</template>

--- a/src/components/ui/carousel/CarouselItem.vue
+++ b/src/components/ui/carousel/CarouselItem.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+import type { WithClassAsProps } from './interface'
+import { useCarousel } from './useCarousel'
+
+const props = defineProps<WithClassAsProps>()
+
+const { orientation } = useCarousel()
+</script>
+
+<template>
+  <div
+    data-slot="carousel-item"
+    role="group"
+    aria-roledescription="slide"
+    :class="
+      cn(
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/carousel/CarouselNext.vue
+++ b/src/components/ui/carousel/CarouselNext.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { ArrowRight } from 'lucide-vue-next'
+
+import type { ButtonVariants } from '@/components/ui/button'
+import { Button } from '@/components/ui/button'
+
+import { cn } from '@/lib/utils'
+
+import type { WithClassAsProps } from './interface'
+import { useCarousel } from './useCarousel'
+
+const props = withDefaults(
+  defineProps<
+    {
+      variant?: ButtonVariants['variant']
+      size?: ButtonVariants['size']
+    } & WithClassAsProps
+  >(),
+  {
+    variant: 'outline',
+    size: 'icon'
+  }
+)
+
+const { orientation, canScrollNext, scrollNext } = useCarousel()
+</script>
+
+<template>
+  <Button
+    data-slot="carousel-next"
+    :disabled="!canScrollNext"
+    :class="
+      cn(
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -right-12 -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+        props.class
+      )
+    "
+    :variant="variant"
+    :size="size"
+    @click="scrollNext"
+  >
+    <slot>
+      <ArrowRight />
+      <span class="sr-only">Next Slide</span>
+    </slot>
+  </Button>
+</template>

--- a/src/components/ui/carousel/CarouselPrevious.vue
+++ b/src/components/ui/carousel/CarouselPrevious.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { ArrowLeft } from 'lucide-vue-next'
+
+import type { ButtonVariants } from '@/components/ui/button'
+import { Button } from '@/components/ui/button'
+
+import { cn } from '@/lib/utils'
+
+import type { WithClassAsProps } from './interface'
+import { useCarousel } from './useCarousel'
+
+const props = withDefaults(
+  defineProps<
+    {
+      variant?: ButtonVariants['variant']
+      size?: ButtonVariants['size']
+    } & WithClassAsProps
+  >(),
+  {
+    variant: 'outline',
+    size: 'icon'
+  }
+)
+
+const { orientation, canScrollPrev, scrollPrev } = useCarousel()
+</script>
+
+<template>
+  <Button
+    data-slot="carousel-previous"
+    :disabled="!canScrollPrev"
+    :class="
+      cn(
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -left-12 -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+        props.class
+      )
+    "
+    :variant="variant"
+    :size="size"
+    @click="scrollPrev"
+  >
+    <slot>
+      <ArrowLeft />
+      <span class="sr-only">Previous Slide</span>
+    </slot>
+  </Button>
+</template>

--- a/src/components/ui/carousel/index.ts
+++ b/src/components/ui/carousel/index.ts
@@ -1,0 +1,8 @@
+export { default as Carousel } from './Carousel.vue'
+export { default as CarouselContent } from './CarouselContent.vue'
+export { default as CarouselItem } from './CarouselItem.vue'
+export { default as CarouselNext } from './CarouselNext.vue'
+export { default as CarouselPrevious } from './CarouselPrevious.vue'
+export type { UnwrapRefCarouselApi as CarouselApi } from './interface'
+
+export { useCarousel } from './useCarousel'

--- a/src/components/ui/carousel/interface.ts
+++ b/src/components/ui/carousel/interface.ts
@@ -1,0 +1,25 @@
+import type useEmblaCarousel from 'embla-carousel-vue'
+import type { EmblaCarouselVueType } from 'embla-carousel-vue'
+
+import type { HTMLAttributes, UnwrapRef } from 'vue'
+
+type CarouselApi = EmblaCarouselVueType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+export type UnwrapRefCarouselApi = UnwrapRef<CarouselApi>
+
+export interface CarouselProps {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: 'horizontal' | 'vertical'
+}
+
+export interface CarouselEmits {
+  (e: 'init-api', payload: UnwrapRefCarouselApi): void
+}
+
+export interface WithClassAsProps {
+  class?: HTMLAttributes['class']
+}

--- a/src/components/ui/carousel/useCarousel.ts
+++ b/src/components/ui/carousel/useCarousel.ts
@@ -1,0 +1,63 @@
+import { createInjectionState } from '@vueuse/core'
+import emblaCarouselVue from 'embla-carousel-vue'
+
+import { onMounted, ref } from 'vue'
+
+import type { UnwrapRefCarouselApi as CarouselApi, CarouselEmits, CarouselProps } from './interface'
+
+const [useProvideCarousel, useInjectCarousel] = createInjectionState(
+  ({ opts, orientation, plugins }: CarouselProps, emits: CarouselEmits) => {
+    const [emblaNode, emblaApi] = emblaCarouselVue(
+      {
+        ...opts,
+        axis: orientation === 'horizontal' ? 'x' : 'y'
+      },
+      plugins
+    )
+
+    function scrollPrev() {
+      emblaApi.value?.scrollPrev()
+    }
+    function scrollNext() {
+      emblaApi.value?.scrollNext()
+    }
+
+    const canScrollNext = ref(false)
+    const canScrollPrev = ref(false)
+
+    function onSelect(api: CarouselApi) {
+      canScrollNext.value = api?.canScrollNext() || false
+      canScrollPrev.value = api?.canScrollPrev() || false
+    }
+
+    onMounted(() => {
+      if (!emblaApi.value) return
+
+      emblaApi.value?.on('init', onSelect)
+      emblaApi.value?.on('reInit', onSelect)
+      emblaApi.value?.on('select', onSelect)
+
+      emits('init-api', emblaApi.value)
+    })
+
+    return {
+      carouselRef: emblaNode,
+      carouselApi: emblaApi,
+      canScrollPrev,
+      canScrollNext,
+      scrollPrev,
+      scrollNext,
+      orientation
+    }
+  }
+)
+
+function useCarousel() {
+  const carouselState = useInjectCarousel()
+
+  if (!carouselState) throw new Error('useCarousel must be used within a <Carousel />')
+
+  return carouselState
+}
+
+export { useCarousel, useProvideCarousel }

--- a/src/components/ui/flickering-grid/FlickeringGrid.vue
+++ b/src/components/ui/flickering-grid/FlickeringGrid.vue
@@ -1,0 +1,179 @@
+<template>
+  <div ref="containerRef" :class="cn('h-full w-full', props.class)">
+    <canvas
+      ref="canvasRef"
+      class="pointer-events-none"
+      :width="canvasSize.width"
+      :height="canvasSize.height"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, onBeforeUnmount, onMounted, ref, toRefs } from 'vue'
+
+import { cn } from '@/lib/utils'
+
+interface FlickeringGridProps {
+  squareSize?: number
+  gridGap?: number
+  flickerChance?: number
+  color?: string
+  width?: number
+  height?: number
+  class?: string
+  maxOpacity?: number
+}
+
+const props = withDefaults(defineProps<FlickeringGridProps>(), {
+  squareSize: 4,
+  gridGap: 6,
+  flickerChance: 0.3,
+  color: 'rgb(0, 0, 0)',
+  maxOpacity: 0.3
+})
+
+const { squareSize, gridGap, flickerChance, color, maxOpacity, width, height } = toRefs(props)
+
+const containerRef = ref<HTMLDivElement>()
+const canvasRef = ref<HTMLCanvasElement>()
+const context = ref<CanvasRenderingContext2D>()
+
+const isInView = ref(false)
+const canvasSize = ref({ width: 0, height: 0 })
+
+const computedColor = computed(() => {
+  if (!context.value) return 'rgba(255, 0, 0,'
+
+  const hex = color.value.replace(/^#/, '')
+  const bigint = Number.parseInt(hex, 16)
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
+  return `rgba(${r}, ${g}, ${b},`
+})
+
+function setupCanvas(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number
+): {
+  cols: number
+  rows: number
+  squares: Float32Array
+  dpr: number
+} {
+  const dpr = window.devicePixelRatio || 1
+  canvas.width = width * dpr
+  canvas.height = height * dpr
+  canvas.style.width = `${width}px`
+  canvas.style.height = `${height}px`
+
+  const cols = Math.floor(width / (squareSize.value + gridGap.value))
+  const rows = Math.floor(height / (squareSize.value + gridGap.value))
+
+  const squares = new Float32Array(cols * rows)
+  for (let i = 0; i < squares.length; i++) {
+    squares[i] = Math.random() * maxOpacity.value
+  }
+  return { cols, rows, squares, dpr }
+}
+
+function updateSquares(squares: Float32Array, deltaTime: number) {
+  for (let i = 0; i < squares.length; i++) {
+    if (Math.random() < flickerChance.value * deltaTime) {
+      squares[i] = Math.random() * maxOpacity.value
+    }
+  }
+}
+
+function drawGrid(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  cols: number,
+  rows: number,
+  squares: Float32Array,
+  dpr: number
+) {
+  ctx.clearRect(0, 0, width, height)
+  ctx.fillStyle = 'transparent'
+  ctx.fillRect(0, 0, width, height)
+  for (let i = 0; i < cols; i++) {
+    for (let j = 0; j < rows; j++) {
+      const opacity = squares[i * rows + j]
+      ctx.fillStyle = `${computedColor.value}${opacity})`
+      ctx.fillRect(
+        i * (squareSize.value + gridGap.value) * dpr,
+        j * (squareSize.value + gridGap.value) * dpr,
+        squareSize.value * dpr,
+        squareSize.value * dpr
+      )
+    }
+  }
+}
+
+const gridParams = ref<ReturnType<typeof setupCanvas>>()
+
+function updateCanvasSize() {
+  const newWidth = width.value || containerRef.value!.clientWidth
+  const newHeight = height.value || containerRef.value!.clientHeight
+
+  canvasSize.value = { width: newWidth, height: newHeight }
+  gridParams.value = setupCanvas(canvasRef.value!, newWidth, newHeight)
+}
+
+let animationFrameId: number | undefined
+let resizeObserver: ResizeObserver | undefined
+let intersectionObserver: IntersectionObserver | undefined
+let lastTime = 0
+
+function animate(time: number) {
+  if (!isInView.value) return
+
+  const deltaTime = (time - lastTime) / 1000
+  lastTime = time
+
+  updateSquares(gridParams.value!.squares, deltaTime)
+  drawGrid(
+    context.value!,
+    canvasRef.value!.width,
+    canvasRef.value!.height,
+    gridParams.value!.cols,
+    gridParams.value!.rows,
+    gridParams.value!.squares,
+    gridParams.value!.dpr
+  )
+  animationFrameId = requestAnimationFrame(animate)
+}
+
+onMounted(() => {
+  if (!canvasRef.value || !containerRef.value) return
+  context.value = canvasRef.value.getContext('2d')!
+  if (!context.value) return
+
+  updateCanvasSize()
+
+  resizeObserver = new ResizeObserver(() => {
+    updateCanvasSize()
+  })
+  intersectionObserver = new IntersectionObserver(
+    ([entry]) => {
+      isInView.value = entry.isIntersecting
+      animationFrameId = requestAnimationFrame(animate)
+    },
+    { threshold: 0 }
+  )
+
+  resizeObserver.observe(containerRef.value)
+  intersectionObserver.observe(canvasRef.value)
+})
+
+onBeforeUnmount(() => {
+  if (animationFrameId) {
+    cancelAnimationFrame(animationFrameId)
+  }
+  resizeObserver?.disconnect()
+  intersectionObserver?.disconnect()
+})
+</script>

--- a/src/components/ui/flickering-grid/index.ts
+++ b/src/components/ui/flickering-grid/index.ts
@@ -1,0 +1,1 @@
+export { default as FlickeringGrid } from './FlickeringGrid.vue'

--- a/src/data/careers.ts
+++ b/src/data/careers.ts
@@ -1,0 +1,38 @@
+export interface Career {
+  id: string
+  company: string
+  title: string
+  years: number
+  description?: string
+}
+
+export const careerList: Career[] = [
+  {
+    id: 'career-1',
+    company: 'Apollo Global Management',
+    title: 'Sr. Software Engineer',
+    years: 1,
+    description: 'TODO: Add description'
+  },
+  {
+    id: 'career-2',
+    company: 'Spartan Radar',
+    title: 'Sr. Software Engineer',
+    years: 3,
+    description: 'TODO: Add description'
+  },
+  {
+    id: 'career-3',
+    company: 'Raytheon',
+    title: 'Software Engineer 2',
+    years: 3,
+    description: 'TODO: Add description'
+  },
+  {
+    id: 'career-4',
+    company: 'Georgia Tech Research Institute',
+    title: 'Intern',
+    years: 1,
+    description: 'TODO: Add description'
+  }
+]

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,9 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
-import HomeView from '../views/HomeView.vue'
+import HomeView from '@/views/HomeView.vue'
+import CareerView from '@/views/CareerView.vue'
+
+
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -9,6 +12,11 @@ const router = createRouter({
       path: '/',
       name: 'home',
       component: HomeView
+    },
+    {
+      path: '/career',
+      name: 'career',
+      component: CareerView
     }
   ]
 })

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,9 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
-import HomeView from '@/views/HomeView.vue'
 import CareerView from '@/views/CareerView.vue'
-
-
+import HomeView from '@/views/HomeView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),

--- a/src/views/CareerView.vue
+++ b/src/views/CareerView.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="flex min-h-full w-full items-center justify-center px-4">
+    <div class="text-center space-y-4 max-w-lg">
+      <!-- Greeting -->
+      <h1 class="text-4xl font-semibold text-gray-800 dark:text-gray-100">
+        Hello this is my career page!
+      </h1>
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/src/views/CareerView.vue
+++ b/src/views/CareerView.vue
@@ -1,4 +1,10 @@
 <script setup lang="ts">
+import { watchOnce } from '@vueuse/core'
+
+import { ref } from 'vue'
+
+import { Card, CardContent } from '@/components/ui/card'
+import type { CarouselApi } from '@/components/ui/carousel'
 import {
   Carousel,
   CarouselContent,
@@ -6,26 +12,47 @@ import {
   CarouselNext,
   CarouselPrevious
 } from '@/components/ui/carousel'
+
+const api = ref<CarouselApi>()
+const totalCount = ref(0)
+const current = ref(0)
+function setApi(val: CarouselApi) {
+  api.value = val
+}
+watchOnce(api, api => {
+  if (!api) return
+  totalCount.value = api.scrollSnapList().length
+  current.value = api.selectedScrollSnap() + 1
+  api.on('select', () => {
+    current.value = api.selectedScrollSnap() + 1
+  })
+})
 </script>
 
 <template>
-  <div class="flex min-h-full w-full items-center justify-center px-4">
-    <div>
-      <Carousel v-slot="{ canScrollNext }" class="relative w-full max-w-xs">
-        <CarouselContent>
-          <CarouselItem v-for="(_, index) in 5" :key="index">
-            <div class="p-1">
-              <Card>
-                <CardContent class="flex aspect-square items-center justify-center p-6">
-                  <span class="text-4xl font-semibold">{{ index + 1 }}</span>
-                </CardContent>
-              </Card>
-            </div>
-          </CarouselItem>
-        </CarouselContent>
-        <CarouselPrevious />
-        <CarouselNext v-if="canScrollNext" />
-      </Carousel>
+  <div class="flex min-h-full w-full flex-col items-center justify-center px-4">
+    <Carousel
+      class="relative w-full max-w-md"
+      v-slot="{ canScrollNext }"
+      @init-api="setApi"
+      :opts="{ loop: true }"
+    >
+      <CarouselContent>
+        <CarouselItem v-for="(_, index) in 5" :key="index">
+          <div class="p-1">
+            <Card>
+              <CardContent class="flex aspect-square items-center justify-center p-6">
+                <span class="text-4xl font-semibold">{{ index + 1 }}</span>
+              </CardContent>
+            </Card>
+          </div>
+        </CarouselItem>
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext v-if="canScrollNext" />
+    </Carousel>
+    <div class="text-muted-foreground mt-4 py-2 text-center text-sm">
+      Career {{ current }} of {{ totalCount }}
     </div>
   </div>
 </template>

--- a/src/views/CareerView.vue
+++ b/src/views/CareerView.vue
@@ -13,6 +13,8 @@ import {
   CarouselPrevious
 } from '@/components/ui/carousel'
 
+import { careerList } from '@/data/careers'
+
 const api = ref<CarouselApi>()
 const totalCount = ref(0)
 const current = ref(0)
@@ -38,11 +40,19 @@ watchOnce(api, api => {
       :opts="{ loop: true }"
     >
       <CarouselContent>
-        <CarouselItem v-for="(_, index) in 5" :key="index">
+        <CarouselItem v-for="(career, index) in careerList" :key="career.id || index">
           <div class="p-1">
             <Card>
               <CardContent class="flex aspect-square items-center justify-center p-6">
-                <span class="text-4xl font-semibold">{{ index + 1 }}</span>
+                <div class="text-center">
+                  <div class="text-2xl font-semibold text-emerald-600 dark:text-emerald-400">
+                    {{ career.company }}
+                  </div>
+                  <div class="text-muted-foreground text-lg">
+                    {{ career.title }} — {{ career.years }} {{ career.years === 1 ? 'yr' : 'yrs' }}
+                  </div>
+                  <p class="mt-2 text-sm" v-if="career.description">{{ career.description }}</p>
+                </div>
               </CardContent>
             </Card>
           </div>

--- a/src/views/CareerView.vue
+++ b/src/views/CareerView.vue
@@ -1,12 +1,31 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious
+} from '@/components/ui/carousel'
+</script>
 
 <template>
   <div class="flex min-h-full w-full items-center justify-center px-4">
-    <div class="text-center space-y-4 max-w-lg">
-      <!-- Greeting -->
-      <h1 class="text-4xl font-semibold text-gray-800 dark:text-gray-100">
-        Hello this is my career page!
-      </h1>
+    <div>
+      <Carousel v-slot="{ canScrollNext }" class="relative w-full max-w-xs">
+        <CarouselContent>
+          <CarouselItem v-for="(_, index) in 5" :key="index">
+            <div class="p-1">
+              <Card>
+                <CardContent class="flex aspect-square items-center justify-center p-6">
+                  <span class="text-4xl font-semibold">{{ index + 1 }}</span>
+                </CardContent>
+              </Card>
+            </div>
+          </CarouselItem>
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext v-if="canScrollNext" />
+      </Carousel>
     </div>
   </div>
 </template>

--- a/src/views/CareerView.vue
+++ b/src/views/CareerView.vue
@@ -51,7 +51,7 @@ watchOnce(api, api => {
                   <div class="text-muted-foreground text-lg">
                     {{ career.title }} — {{ career.years }} {{ career.years === 1 ? 'yr' : 'yrs' }}
                   </div>
-                  <p class="mt-2 text-sm" v-if="career.description">{{ career.description }}</p>
+                  <!-- <p class="mt-2 text-sm" v-if="career.description">{{ career.description }}</p> -->
                 </div>
               </CardContent>
             </Card>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -2,25 +2,23 @@
 
 <template>
   <div class="flex min-h-full w-full items-center justify-center px-4">
-    <div class="text-center space-y-4 max-w-lg">
+    <div class="max-w-lg space-y-4 text-center">
       <!-- Greeting -->
-      <h1 class="text-4xl font-semibold text-gray-800 dark:text-gray-100">
-        Hello, World!
-      </h1>
+      <h1 class="text-4xl font-semibold text-gray-800 dark:text-gray-100">Hello, World!</h1>
 
       <!-- Intro / Profession -->
       <h2 class="text-xl font-medium text-gray-700 dark:text-gray-300">
-        I'm a <span class="text-emerald-600 dark:text-emerald-400 font-semibold">Software</span>
-        and <span class="text-emerald-600 dark:text-emerald-400 font-semibold">DevOps</span> Engineer.
+        I'm a <span class="font-semibold text-emerald-600 dark:text-emerald-400">Software</span> and
+        <span class="font-semibold text-emerald-600 dark:text-emerald-400">DevOps</span> Engineer.
       </h2>
 
       <!-- Description -->
-      <p class="text-base text-gray-600 dark:text-gray-400 leading-relaxed">
+      <p class="text-base leading-relaxed text-gray-600 dark:text-gray-400">
         This is my work-in-progress resume page built on
         <span class="font-medium text-emerald-600 dark:text-emerald-400">Vue&nbsp;3</span>,
-        <span class="font-medium text-emerald-600 dark:text-emerald-400">Tailwind&nbsp;CSS</span>, and
-        <span class="font-medium text-emerald-600 dark:text-emerald-400">shadcn-vue</span>,
-        and deployed on
+        <span class="font-medium text-emerald-600 dark:text-emerald-400">Tailwind&nbsp;CSS</span>,
+        and <span class="font-medium text-emerald-600 dark:text-emerald-400">shadcn-vue</span>, and
+        deployed on
         <span class="font-medium text-emerald-600 dark:text-emerald-400">GitHub&nbsp;Pages</span>.
       </p>
     </div>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -8,18 +8,18 @@
 
       <!-- Intro / Profession -->
       <h2 class="text-xl font-medium text-gray-700 dark:text-gray-300">
-        I'm a <span class="font-semibold text-emerald-600 dark:text-emerald-400">Software</span> and
-        <span class="font-semibold text-emerald-600 dark:text-emerald-400">DevOps</span> Engineer.
+        I'm a <span class="font-semibold text-emerald-700 dark:text-emerald-400">Software</span> and
+        <span class="font-semibold text-emerald-700 dark:text-emerald-400">DevOps</span> Engineer.
       </h2>
 
       <!-- Description -->
-      <p class="text-base leading-relaxed text-gray-600 dark:text-gray-400">
+      <p class="text-base leading-relaxed text-gray-800 dark:text-gray-400">
         This is my work-in-progress resume page built on
-        <span class="font-medium text-emerald-600 dark:text-emerald-400">Vue&nbsp;3</span>,
-        <span class="font-medium text-emerald-600 dark:text-emerald-400">Tailwind&nbsp;CSS</span>,
-        and <span class="font-medium text-emerald-600 dark:text-emerald-400">shadcn-vue</span>, and
+        <span class="font-medium text-emerald-700 dark:text-emerald-400">Vue&nbsp;3</span>,
+        <span class="font-medium text-emerald-700 dark:text-emerald-400">Tailwind&nbsp;CSS</span>,
+        and <span class="font-medium text-emerald-700 dark:text-emerald-400">shadcn-vue</span>, and
         deployed on
-        <span class="font-medium text-emerald-600 dark:text-emerald-400">GitHub&nbsp;Pages</span>.
+        <span class="font-medium text-emerald-700 dark:text-emerald-400">GitHub&nbsp;Pages</span>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
- Create a `/career` endpoint with a `data/careers.ts`
- Integrate a carousel to display different careers in a card
- Integrate a flickering background grid from Inspira-UI, persistent in all routes
- Fixed various issues in content shifting from sidebar opening and color flashes when changing routes